### PR TITLE
Use docker node:10-alpine instead of node:lts-alpine.

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:10-alpine
 
 # install simple http server for serving static content
 RUN npm install -g http-server


### PR DESCRIPTION
lts-alpine is a mutable tag. Docker Hub will continue to update the image, so it no longer points to the node version when the project was created, but to the current LTS latest version.

In the current LTS latest version 22.17, siteserver will throw the error:0308010C:digital envelope routines::unsupported.

Refs: https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported

P.S. Use node:10 because https://github.com/craigloewen-msft/ghostgame/blob/066c10baaefbb023542b7a06b2b76f46950a7fd0/socketLogic/Dockerfile#L2 uses node:10.